### PR TITLE
fix: run build on CI unconditionally

### DIFF
--- a/.changeset/fresh-houses-listen.md
+++ b/.changeset/fresh-houses-listen.md
@@ -1,0 +1,5 @@
+---
+"@dual-bundle/import-meta-resolve": patch
+---
+
+fix: run build on CI unconditionally

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
+      - name: Build
+        run: npm run build
+
       - name: Publish to npm
         uses: changesets/action@v1
         with:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add a `Build` step to the CI workflow in `release.yml` to run `npm run build` unconditionally before publishing.
> 
>   - **CI Workflow**:
>     - Adds a `Build` step in `.github/workflows/release.yml` to run `npm run build` unconditionally before publishing to npm.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-es%2Fimport-meta-resolve&utm_source=github&utm_medium=referral)<sup> for 6ae7af5b5dfccd0291b9adfeea35bac62e34b2a9. You can [customize](https://app.ellipsis.dev/un-es/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated release workflow to always run a build before publishing, improving the reliability and consistency of released packages.
  - Added release metadata to track this process adjustment and ensure correct versioning.

- Bug Fixes
  - Ensures build steps run unconditionally during releases, reducing the risk of incomplete or broken publishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->